### PR TITLE
#32-문서 작성 페이지 기능 일부 구현(텍스트 에디터, 저장, 내보내기, 취소)

### DIFF
--- a/src/main/java/com/example/BookHub/HomeController.java
+++ b/src/main/java/com/example/BookHub/HomeController.java
@@ -3,6 +3,9 @@ package com.example.BookHub;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 @RequiredArgsConstructor
 @Controller
@@ -15,4 +18,12 @@ public class HomeController {
 
     @GetMapping("/signup")
     public String signUp() {return "signup";}
+
+    @PostMapping("/save")
+    @ResponseBody
+    public String saveEditorContent(@RequestParam("editorContent") String editorContent,
+                                    @RequestParam("title") String title, @RequestParam("memo") String memo) {
+
+        return "success";
+    }
 }

--- a/src/main/webapp/WEB-INF/views/writeform.jsp
+++ b/src/main/webapp/WEB-INF/views/writeform.jsp
@@ -20,11 +20,29 @@
       <textarea id="editor"></textarea>
     </div>
 
+    <div class="buttonContainer">
+      <button id="export" onclick="printEditorContent()">내보내기</button>
+    </div>
+
   </div>
     <script>
       tinymce.init({
         selector: '#editor',
       });
+
+      function printEditorContent() {
+        let editorContent = tinymce.activeEditor.getContent();
+
+        let printFrame = document.createElement('iframe');
+        printFrame.style.display = 'none';
+        document.body.appendChild(printFrame);
+        // iframe에 에디터 내용 로드
+        printFrame.contentDocument.write(editorContent);
+        // 출력 실행
+        printFrame.contentWindow.print();
+        // iframe 제거
+        document.body.removeChild(printFrame);
+      }
     </script>
   </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/writeform.jsp
+++ b/src/main/webapp/WEB-INF/views/writeform.jsp
@@ -23,6 +23,7 @@
     <div class="buttonContainer">
       <button id="export" onclick="printEditorContent()">내보내기</button>
       <button id="save" onclick="saveEditorContent()">저장</button>
+      <button id="cancel" onclick="cancelWrite()">취소</button>
     </div>
 
     <!-- 모달창 추가 -->
@@ -94,6 +95,16 @@
         let closeButton = document.getElementsByClassName("close")[0];
         closeButton.onclick = function() {
           modal.style.display = "none";
+        }
+      }
+
+      function cancelWrite() {
+        if (confirm("작성중인 내용이 초기화됩니다. 진행하시겠습니까?")) {
+          // 작성중인 내용 초기화
+          tinymce.activeEditor.setContent('');
+
+          // 문서 리스트 화면으로 이동
+          location.href = '/document/list';
         }
       }
     </script>

--- a/src/main/webapp/WEB-INF/views/writeform.jsp
+++ b/src/main/webapp/WEB-INF/views/writeform.jsp
@@ -1,24 +1,31 @@
-<!-- Include Quill stylesheet -->
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<link href="https://cdn.quilljs.com/1.0.0/quill.snow.css" rel="stylesheet" />
-<!-- Create the toolbar container -->
-<div id="toolbar">
-  <button class="ql-bold">Bold</button>
-  <button class="ql-italic">Italic</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>TinyMCE compare document</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
 
-<!-- Create the editor container -->
-<div id="editor">
-  <p>Hello World!</p>
-</div>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
-<!-- Include the Quill library -->
-<script src="https://cdn.quilljs.com/1.0.0/quill.js"></script>
+    <!-- tinymce6 라이브러리 추가 -->
+    <script src="https://cdn.tiny.cloud/1/l4hh05dskpwmkxxbt2c4q7ilmuby0zfysfofsdaujbvuyjr1/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
 
-<!-- Initialize Quill editor -->
-<script>
-  let editor = new Quill('#editor', {
-    modules: { toolbar: '#toolbar' },
-    theme: 'snow',
-  });
-</script>
+  </head>
+  <body>
+    <div class="editorContainer">
+      <textarea id="editor"></textarea>
+    </div>
+
+  </div>
+    <script>
+      tinymce.init({
+        selector: '#editor',
+      });
+    </script>
+  </body>
+</html>
+

--- a/src/main/webapp/WEB-INF/views/writeform.jsp
+++ b/src/main/webapp/WEB-INF/views/writeform.jsp
@@ -22,6 +22,19 @@
 
     <div class="buttonContainer">
       <button id="export" onclick="printEditorContent()">내보내기</button>
+      <button id="save" onclick="saveEditorContent()">저장</button>
+    </div>
+
+    <!-- 모달창 추가 -->
+    <div id="myModal" class="modal">
+      <div class="modal-content">
+        <h2>Title</h2>
+        <input type="text" id="modal-title">
+        <h2>Memo</h2>
+        <textarea id="modal-memo"></textarea>
+        <button id="save-button">저장</button>
+        <button class="close">취소</button>
+      </div>
     </div>
 
   </div>
@@ -42,6 +55,46 @@
         printFrame.contentWindow.print();
         // iframe 제거
         document.body.removeChild(printFrame);
+      }
+
+      function saveEditorContent() {
+        let editorContent = tinymce.activeEditor.getContent();
+        console.log(editorContent);
+
+        // 모달창 띄우기
+        let modal = document.getElementById("myModal");
+        modal.style.display = "block";
+
+        // 모달창 안에 저장 버튼에 이벤트 추가
+        let saveButton = document.getElementById("save-button");
+        saveButton.onclick = function() {
+          let title = document.getElementById("modal-title").value;
+          let memo = document.getElementById("modal-memo").value;
+          $.ajax({
+            type: "POST",
+            url: "/save",
+            data: {
+              editorContent: editorContent,
+              title: title,
+              memo: memo
+            },
+            success: function(response) {
+              console.log(response);
+            },
+            error: function(xhr, status, error) {
+              console.error(error);
+            }
+          });
+
+          // 모달창 닫기
+          modal.style.display = "none";
+        }
+
+        // 모달창의 X 버튼을 누르면 모달창 닫기
+        let closeButton = document.getElementsByClassName("close")[0];
+        closeButton.onclick = function() {
+          modal.style.display = "none";
+        }
       }
     </script>
   </body>


### PR DESCRIPTION
### 문서 작성 페이지 기능 구현


1. 텍스트 에디터 추가
   - tinyMCE6 텍스트 에디터를 선정하여 라이브러리를 사용하고 초기화(init)하여 페이지 적용하였습니다.

2. 내보내기 기능 구현 
   - 내보내기 버튼을 추가하고 PDF 파일 형식으로 저장하는 기능을 구현했습니다.
   - 내보내기 버튼 추가(id="export")
   - function printEditorContent()
      -  내보내기 버튼을 누를 시 실행하며 에디터에 작성된 내용을 로드하여 PDF 파일로 출력(저장)하는 기능을 수행

3. 저장 기능 구현
   - tinyMCE에디터에 작성된 내용과 modal에서 작성된 제목,메모를 컨트롤러로 전달하는 기능을 구현했습니다.
   - [writeform.jsp 수정]
      - '저장'버튼, modal 구현
      - function saveEditorContent()
         - '저장'버튼 클릭 시 modal을 띄운다.
         - modal에서는 title, memo를 입력할 수 있다.
         - modal의 '저장' 버튼을 클릭하면 content, title, memo를 controller로 전달한다.
         - ajax를 사용하여 POST 방식으로 전달하며 임시로 '/save'로 전달한다.  
   - [HomeController.java 수정]
      - public String saveEditorContent()
      - 임시로 테스트를 위하여 HomeController에 위 메서드를 작성
      - content, title, memo를 전달받고 "success"를 리턴한다.

4. 취소 기능 구현
   - 취소 버튼을 클릭하면 confirm 창을 띄워서 확인하고 문서의 리스트로 돌아가는 기능을 구현했습니다.
   - [writeform.jsp 수정]
      - 취소 버튼 추가
      - function cancelWrite()
         - 취소 버튼을 눌렀을 시 실행 된다.
         - confirm 창을 띄우고 '확인'을 눌렀을 시 작성중인 내용을 초기화 하고 문서 리스트로 이동한다.
         - 현재는 임시로 '/document/list'로 이동하도록 구현