### PR TITLE
Feature/#82 맞춤법api적용

### DIFF
--- a/src/main/resources/static/css/writeform.css
+++ b/src/main/resources/static/css/writeform.css
@@ -132,3 +132,11 @@ body{
     margin-bottom: 20px;
 
 }
+
+.editorContainer {
+    display: flex;
+    flex-direction: row;
+}
+#spellCheckResult {
+    width: 30%;
+}

--- a/src/main/resources/static/js/writeform.js
+++ b/src/main/resources/static/js/writeform.js
@@ -1,0 +1,101 @@
+tinymce.init({
+    selector: '#editor',
+    height: '700px',
+    width: '70%'
+});
+
+function printEditorContent() {
+    let editorContent = tinymce.activeEditor.getContent();
+
+    let printFrame = document.createElement('iframe');
+    printFrame.style.display = 'none';
+    document.body.appendChild(printFrame);
+    printFrame.contentDocument.write(editorContent);
+    printFrame.contentWindow.print();
+    document.body.removeChild(printFrame);
+}
+
+function saveEditorContent() {
+    let editorContent = tinymce.activeEditor.getContent();
+    console.log(editorContent);
+
+    let modal = document.getElementById("myModal");
+    modal.style.display = "block";
+
+    let saveButton = document.getElementById("save-button");
+    saveButton.onclick = function() {
+        let title = document.getElementById("modal-title").value;
+        let memo = document.getElementById("modal-memo").value;
+        $.ajax({
+            type: "POST",
+            url: "/save",
+            data: {
+                editorContent: editorContent,
+                title: title,
+                memo: memo
+            },
+            success: function(response) {
+                console.log(response);
+            },
+            error: function(xhr, status, error) {
+                console.error(error);
+            }
+        });
+        modal.style.display = "none";
+    }
+
+    let closeButton = document.getElementById("close-button");
+    closeButton.onclick = function() {
+        modal.style.display = "none";
+    }
+}
+
+function cancelWrite() {
+    if (confirm("작성중인 내용이 초기화됩니다. 진행하시겠습니까?")) {
+        tinymce.activeEditor.setContent('');
+        location.href = '/document/list';
+    }
+}
+
+function copyEditorContent() {
+    let editorContent = tinymce.activeEditor.getContent({format: 'text'});
+    navigator.clipboard.writeText(editorContent)
+        .then(() => {
+            console.log('Editor content copied to clipboard');
+            alert('복사가 완료되었습니다.');
+        })
+        .catch((error) => {
+            console.error('Error copying editor content to clipboard:', error);
+        });
+}
+
+function spellCheck() {
+    let editorContent = tinymce.activeEditor.getContent({format: 'text'});
+
+    const content = {
+        content : editorContent
+    };
+
+    $.ajax({
+        type: "POST",
+        url: "http://54.66.159.191:3000/spellcheck",
+        data: JSON.stringify(content),
+        contentType: "application/json; charset=utf-8",
+        dataType: "json",
+        success: function(result) {
+            console.log(result)
+            let spellCheckTextArea = document.getElementById("spellCheckResult");
+            spellCheckTextArea.innerHTML = ''; // 기존 값 초기화
+            let suggestions = '';
+            for (let i = 0; i < result[0].length; i++) {
+                let token = result[0][i].token;
+                let sugesstions = result[0][i].suggestions.join(", ");
+                suggestions += token + " -> " + sugesstions + "\n\n";
+            }
+            spellCheckTextArea.innerHTML = suggestions;
+
+        },  error: function() {
+            console.log('통신실패!!');
+        },
+    });
+}

--- a/src/main/webapp/WEB-INF/views/writeform.jsp
+++ b/src/main/webapp/WEB-INF/views/writeform.jsp
@@ -12,9 +12,14 @@
   <meta name='viewport' content='width=device-width, initial-scale=1'>
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+        integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <link rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,400,0,0"/>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+          crossorigin="anonymous"></script>
   <link href="/css/writeform.css" rel="stylesheet" type="text/css">
-  <!-- tinymce6 라이브러리 추가 -->
   <script src="https://cdn.tiny.cloud/1/l4hh05dskpwmkxxbt2c4q7ilmuby0zfysfofsdaujbvuyjr1/tinymce/6/tinymce.min.js" referrerpolicy="origin"></script>
 </head>
 <body>
@@ -28,7 +33,7 @@
     <div class="buttonContainer">
       <button class="btn btn-outline-dark" id="save" onclick="saveEditorContent()"><img class="buttonImg" src="/img/save.png"/></button>
       <button class="btn btn-outline-dark" id="copy" onclick="copyEditorContent()"><img class="buttonImg" src="/img/copy.png"/></button>
-      <button class="btn btn-outline-dark" id="spellCheckLink" onclick="openSpellCheck()">Naver 맞춤법 검사</button>
+      <button class="btn btn-outline-dark" id="spellCheckLink" onclick="spellCheck()">맞춤법 검사</button>
       <button class="btn btn-outline-dark" id="export" onclick="printEditorContent()">내보내기</button>
       <button class="btn btn-outline-dark" id="cancel" onclick="cancelWrite()">취소</button>
     </div>
@@ -37,12 +42,12 @@
         <button class="btn btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown"
                 aria-expanded="false">
           <% Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-           String userName = null;
-           if (auth != null && !auth.getName().equals("anonymousUser")) {
-             userName = auth.getName();
-           } else if (session != null){
-             userName = ((UserDTO) session.getAttribute(LOGIN_USER)).getName();
-           }%>
+            String userName = null;
+            if (auth != null && !auth.getName().equals("anonymousUser")) {
+              userName = auth.getName();
+            } else if (session != null){
+              userName = ((UserDTO) session.getAttribute(LOGIN_USER)).getName();
+            }%>
           <%= userName %>
         </button>
         <ul class="dropdown-menu">
@@ -57,6 +62,7 @@
 
   <div class="editorContainer">
     <textarea id="editor"></textarea>
+    <textarea id="spellCheckResult" disabled></textarea>
   </div>
 
   <div id="myModal" class="modal">
@@ -75,86 +81,9 @@
   </div>
 
 </div>
-<script>
-  tinymce.init({
-    selector: '#editor',
-    height: '700px'
-  });
 
-  function printEditorContent() {
-    let editorContent = tinymce.activeEditor.getContent();
+<script src="/js/writeform.js"></script>
 
-    let printFrame = document.createElement('iframe');
-    printFrame.style.display = 'none';
-    document.body.appendChild(printFrame);
-    printFrame.contentDocument.write(editorContent);
-    printFrame.contentWindow.print();
-    document.body.removeChild(printFrame);
-  }
-
-  function saveEditorContent() {
-    let editorContent = tinymce.activeEditor.getContent();
-    console.log(editorContent);
-
-    let modal = document.getElementById("myModal");
-    modal.style.display = "block";
-
-    let saveButton = document.getElementById("save-button");
-    saveButton.onclick = function() {
-      let title = document.getElementById("modal-title").value;
-      let memo = document.getElementById("modal-memo").value;
-      $.ajax({
-        type: "POST",
-        url: "/save",
-        data: {
-          editorContent: editorContent,
-          title: title,
-          memo: memo
-        },
-        success: function(response) {
-          console.log(response);
-        },
-        error: function(xhr, status, error) {
-          console.error(error);
-        }
-      });
-      modal.style.display = "none";
-    }
-
-    let closeButton = document.getElementById("close-button");
-    closeButton.onclick = function() {
-      modal.style.display = "none";
-    }
-  }
-
-  function cancelWrite() {
-    if (confirm("작성중인 내용이 초기화됩니다. 진행하시겠습니까?")) {
-      tinymce.activeEditor.setContent('');
-      location.href = '/folder/list';
-    }
-  }
-
-  function copyEditorContent() {
-    let editorContent = tinymce.activeEditor.getContent({format: 'text'});
-    navigator.clipboard.writeText(editorContent)
-            .then(() => {
-              console.log('Editor content copied to clipboard');
-              alert('복사가 완료되었습니다.');
-            })
-            .catch((error) => {
-              console.error('Error copying editor content to clipboard:', error);
-            });
-  }
-
-  function openSpellCheck() {
-    const naverSpellCheckerUrl = 'https://search.naver.com/search.naver?where=nexearch&sm=top_hty&fbm=1&ie=utf8&query=%EB%A7%9E%EC%B6%A4%EB%B2%95+%EA%B2%80%EC%82%AC'
-    window.open(naverSpellCheckerUrl);
-  }
-</script>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
-        crossorigin="anonymous"></script>
 </body>
 </html>
 


### PR DESCRIPTION
[맞춤법 검사 API 사용 구현 로직]

맞춤법 검사 기능을 사용하기 위해 node 서버의 hanspell api와 연동 및 js 파일 분리

1. 맞춤법 검사 기능 구현 API를 설치해 놓은 Node 서버와 연결하여 맞춤법 검사 문자열을 전달하고 검사 결과를 json 객체 배열로 받아 화면에 출력해주는 함수 구현

2. js 코드의 길이가 너무 길어져 writeform.js 파일을 생성하여 분리

문서작성 관련 jsp, css 파일 수정

jsp 에서 writeform.js 파일을 사용하도록 변경하고 에디터 옆 맞춤법 검사 결과가 나오는 부분 추가, 이에 적용할 css 파일 수정
